### PR TITLE
chore: add library_type to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,5 +4,5 @@
     "name_pretty": "Google Cloud Platform environment queries",
     "language": "ruby",
     "repo": "googleapis/ruby-cloud-env",
-    "library_type": "GAPIC_MANUAL"
+    "library_type": "CORE"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -3,5 +3,6 @@
     "distribution_name": "google-cloud-env",
     "name_pretty": "Google Cloud Platform environment queries",
     "language": "ruby",
-    "repo": "googleapis/ruby-cloud-env"
+    "repo": "googleapis/ruby-cloud-env",
+    "library_type": "GAPIC_MANUAL"
 }


### PR DESCRIPTION
Add an additional field called library_type to the .repo-metadata.json file. This is part of internal issue #184315365.