### PR TITLE
fix: Drop support for Ruby 2.6

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -6,13 +6,13 @@ branchProtectionRules:
   isAdminEnforced: false
   requiredStatusCheckContexts:
     - 'cla/google'
-    - 'CI (macos-latest, 3.0, test)'
-    - 'CI (ubuntu-latest, 2.6, test)'
+    - 'CI (macos-latest, 3.2, test)'
     - 'CI (ubuntu-latest, 2.7, test)'
-    - 'CI (ubuntu-latest, 3.0, rubocop , build , yardoc , linkinator)'
     - 'CI (ubuntu-latest, 3.0, test)'
     - 'CI (ubuntu-latest, 3.1, test)'
-    - 'CI (windows-latest, 3.0, test)'
+    - 'CI (ubuntu-latest, 3.2, test)'
+    - 'CI (ubuntu-latest, 3.2, rubocop , build , yardoc , linkinator)'
+    - 'CI (windows-latest, 3.2, test)'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ruby: "2.6"
-            task: test
-          - os: ubuntu-latest
             ruby: "2.7"
             task: test
           - os: ubuntu-latest
@@ -25,26 +22,29 @@ jobs:
           - os: ubuntu-latest
             ruby: "3.1"
             task: test
+          - os: ubuntu-latest
+            ruby: "3.2"
+            task: test
           - os: macos-latest
-            ruby: "3.0"
+            ruby: "3.2"
             task: test
           - os: windows-latest
-            ruby: "3.0"
+            ruby: "3.2"
             task: test
           - os: ubuntu-latest
-            ruby: "3.0"
+            ruby: "3.2"
             task: rubocop , build , yardoc , linkinator
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ matrix.ruby }}"
     - name: Install NodeJS 16.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: "16.x"
     - name: Install tools

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,11 +4,9 @@ inherit_gem:
 AllCops:
   Exclude:
     - "test/**/*"
+    - "node_modules/**/*"
 Metrics/ClassLength:
-  Exclude:
-    - "lib/google/cloud/env.rb"
+  Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-env.rb"
-Style/Documentation:
-  Enabled: false

--- a/.toys/.toys.rb
+++ b/.toys/.toys.rb
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+toys_version! ">= 0.15.2"
+
 expand :clean, paths: :gitignore
 
 expand :minitest do |t|
   t.libs = ["lib", "test"]
   t.use_bundler
   t.files = "test/**/*_test.rb"
+  t.mt_compat = true
 end
 
 expand :rubocop, bundler: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,12 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "autotest-suffix", "~> 1.1"
+gem "google-style", "~> 1.27.0"
+gem "minitest", "~> 5.16"
+gem "minitest-autotest", "~> 1.0"
+gem "minitest-focus", "~> 1.1"
+gem "minitest-rg", "~> 5.2"
+gem "redcarpet", "~> 3.0"
+gem "yard", "~> 0.9"

--- a/google-cloud-env.gemspec
+++ b/google-cloud-env.gemspec
@@ -18,23 +18,14 @@ Gem::Specification.new do |gem|
   gem.files         = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + ["LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.6"
+  gem.required_ruby_version = ">= 2.7"
 
-  gem.add_dependency "faraday", ">= 0.17.3", "< 3.a"
-
-  gem.add_development_dependency "autotest-suffix", "~> 1.1"
-  gem.add_development_dependency "google-style", "~> 1.26.1"
-  gem.add_development_dependency "minitest", "~> 5.16"
-  gem.add_development_dependency "minitest-autotest", "~> 1.0"
-  gem.add_development_dependency "minitest-focus", "~> 1.1"
-  gem.add_development_dependency "minitest-rg", "~> 5.2"
-  gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_dependency "faraday", ">= 1.0", "< 3.a"
 
   if gem.respond_to? :metadata
-    gem.metadata["changelog_uri"] = "https://googleapis.dev/ruby/google-cloud-env/v#{gem_version}/file.CHANGELOG.html"
+    gem.metadata["changelog_uri"] = "https://rubydoc.info/gems/google-cloud-env/#{gem_version}/CHANGELOG.md"
     gem.metadata["source_code_uri"] = "https://github.com/googleapis/ruby-cloud-env"
     gem.metadata["bug_tracker_uri"] = "https://github.com/googleapis/ruby-cloud-env/issues"
-    gem.metadata["documentation_uri"] = "https://googleapis.dev/ruby/google-cloud-env/v#{gem_version}"
+    gem.metadata["documentation_uri"] = "https://rubydoc.info/gems/google-cloud-env/#{gem_version}"
   end
 end

--- a/lib/google/cloud/env.rb
+++ b/lib/google/cloud/env.rb
@@ -16,8 +16,13 @@
 require "faraday"
 require "json"
 
-
+##
+# Namespace of Google products
+#
 module Google
+  ##
+  # Namespace of Google Cloud products
+  #
   module Cloud
     ##
     # # Google Cloud hosting environment

--- a/lib/google/cloud/env/version.rb
+++ b/lib/google/cloud/env/version.rb
@@ -16,6 +16,10 @@
 module Google
   module Cloud
     class Env
+      ##
+      # Library version
+      # @return [String]
+      #
       VERSION = "1.6.0".freeze
     end
   end


### PR DESCRIPTION
Also updates the CI matrix and the google-style version, and updates Toys to deal with the minitest-rg issue.