### PR TITLE
fix: Fixed edge cases in token expiration extraction

### DIFF
--- a/lib/google/cloud/env/compute_metadata.rb
+++ b/lib/google/cloud/env/compute_metadata.rb
@@ -806,7 +806,7 @@ module Google
         #
         def access_token_lifetime data
           json = JSON.parse data rescue nil
-          return 0 unless json&.key? "expires_in"
+          return 0 if !json.respond_to?(:key?) || !json&.key?("expires_in")
           lifetime = json["expires_in"].to_i - TOKEN_EXPIRY_BUFFER
           lifetime = 0 if lifetime.negative?
           lifetime
@@ -818,9 +818,9 @@ module Google
         #
         def identity_token_lifetime data
           return 0 unless data =~ /^[\w=-]+\.([\w=-]+)\.[\w=-]+$/
-          base64 = Base64.decode64 Regexp.last_match[1]
+          base64 = Base64.urlsafe_decode64 Regexp.last_match[1]
           json = JSON.parse base64 rescue nil
-          return 0 unless json&.key? "exp"
+          return 0 if !json.respond_to?(:key?) || !json&.key?("exp")
           lifetime = json["exp"].to_i - Time.now.to_i - TOKEN_EXPIRY_BUFFER
           lifetime = 0 if lifetime.negative?
           lifetime

--- a/lib/google/cloud/env/compute_metadata.rb
+++ b/lib/google/cloud/env/compute_metadata.rb
@@ -806,7 +806,7 @@ module Google
         #
         def access_token_lifetime data
           json = JSON.parse data rescue nil
-          return 0 if !json.respond_to?(:key?) || !json&.key?("expires_in")
+          return 0 unless json.respond_to?(:key?) && json.key?("expires_in")
           lifetime = json["expires_in"].to_i - TOKEN_EXPIRY_BUFFER
           lifetime = 0 if lifetime.negative?
           lifetime
@@ -820,7 +820,7 @@ module Google
           return 0 unless data =~ /^[\w=-]+\.([\w=-]+)\.[\w=-]+$/
           base64 = Base64.urlsafe_decode64 Regexp.last_match[1]
           json = JSON.parse base64 rescue nil
-          return 0 if !json.respond_to?(:key?) || !json&.key?("exp")
+          return 0 unless json.respond_to?(:key?) && json&.key?("exp")
           lifetime = json["exp"].to_i - Time.now.to_i - TOKEN_EXPIRY_BUFFER
           lifetime = 0 if lifetime.negative?
           lifetime

--- a/test/google/cloud/env/lazy_value_test.rb
+++ b/test/google/cloud/env/lazy_value_test.rb
@@ -522,7 +522,7 @@ describe Google::Cloud::Env::LazyValue do
 
     it "reflects computing state" do
       cache = Google::Cloud::Env::LazyValue.new do
-        sleep 0.2
+        sleep 0.3
         2
       end
       start_time = nil


### PR DESCRIPTION
Two fixes:

* ID token parsing to get the expiration date, incorrectly used traditional (rather than urlsafe) base64 parsing.
* Expiration defaulted to no expiration if token parsing failed (e.g. in 4xx error cases) resulting in permanently cached error states. Changed to default to zero lifetime.