### PR TITLE
Update error handling for jruby 10

### DIFF
--- a/.toys/linkinator.rb
+++ b/.toys/linkinator.rb
@@ -30,7 +30,12 @@ def run
 end
 
 def check_links
-  result = exec ["npx", "linkinator", "./doc"], out: :capture
+  cmd = [
+    "npx", "linkinator", "./doc",
+    "--reetry-errors",
+    "--skip", "^https?://stackoverflow\\.com/questions/tagged/google-cloud-platform\\+ruby$"
+  ]
+  result = exec cmd, out: :capture
   puts result.captured_out
   checked_links = result.captured_out.split "\n"
   checked_links.select! { |link| link =~ /^\[(\d+)\]/ && ::Regexp.last_match[1] != "200" }

--- a/lib/google/cloud/env/compute_smbios.rb
+++ b/lib/google/cloud/env/compute_smbios.rb
@@ -119,23 +119,20 @@ module Google
         private_constant :WINDOWS_KEYPATH, :WINDOWS_KEYNAME, :LINUX_FILEPATH
 
         def load_product_name
-        begin
-          require "win32/registry"
-          Win32::Registry::HKEY_LOCAL_MACHINE.open WINDOWS_KEYPATH do |reg|
-            return [reg[WINDOWS_KEYNAME].to_s, :windows]
-          end
-        rescue LoadError
-          # Fall through to the Linux routine
-        rescue StandardError => e
-          # With JRuby 10, a Fiddle::DLError is raised, In the case the fiddle gem is not
-          # loadable, safely assert the error type without relying on the Fiddle namespace
-          # having been loaded.
-          if e.class.name == "Fiddle::DLError"
+          begin
+            require "win32/registry"
+            Win32::Registry::HKEY_LOCAL_MACHINE.open WINDOWS_KEYPATH do |reg|
+              return [reg[WINDOWS_KEYNAME].to_s, :windows]
+            end
+          rescue LoadError
             # Fall through to the Linux routine
-          else
-            raise e
+          rescue StandardError => e
+            # With JRuby 10, a Fiddle::DLError is raised, In the case the fiddle gem is not
+            # loadable, safely assert the error type without relying on the Fiddle namespace
+            # having been loaded.
+            raise e unless e.class.name == "Fiddle::DLError" # rubocop:disable Style/ClassEqualityComparison
+            # Fall through to the Linux routine
           end
-        end
           begin
             File.open LINUX_FILEPATH do |file|
               return [file.readline(chomp: true), :linux]

--- a/lib/google/cloud/env/compute_smbios.rb
+++ b/lib/google/cloud/env/compute_smbios.rb
@@ -123,7 +123,7 @@ module Google
           Win32::Registry::HKEY_LOCAL_MACHINE.open WINDOWS_KEYPATH do |reg|
             return [reg[WINDOWS_KEYNAME].to_s, :windows]
           end
-        rescue LoadError
+        rescue LoadError, Fiddle::DLError
           begin
             File.open LINUX_FILEPATH do |file|
               return [file.readline(chomp: true), :linux]

--- a/lib/google/cloud/env/compute_smbios.rb
+++ b/lib/google/cloud/env/compute_smbios.rb
@@ -119,11 +119,23 @@ module Google
         private_constant :WINDOWS_KEYPATH, :WINDOWS_KEYNAME, :LINUX_FILEPATH
 
         def load_product_name
+        begin
           require "win32/registry"
           Win32::Registry::HKEY_LOCAL_MACHINE.open WINDOWS_KEYPATH do |reg|
             return [reg[WINDOWS_KEYNAME].to_s, :windows]
           end
-        rescue LoadError, Fiddle::DLError
+        rescue LoadError
+          # Fall through to the Linux routine
+        rescue StandardError => e
+          # With JRuby 10, a Fiddle::DLError is raised, In the case the fiddle gem is not
+          # loadable, safely assert the error type without relying on the Fiddle namespace
+          # having been loaded.
+          if e.class.name == "Fiddle::DLError"
+            # Fall through to the Linux routine
+          else
+            raise e
+          end
+        end
           begin
             File.open LINUX_FILEPATH do |file|
               return [file.readline(chomp: true), :linux]


### PR DESCRIPTION
With jruby 10 there is a new error type not caught by `LoadError`. This appears to be fallout from this https://github.com/jruby/jruby/pull/8385 refactor. This commit updates the rescue block to handle the existing `LoadError` as well as the `Fiddle::DLError` error. This should bridge compatability between jruby 9 and 10.