### PR TITLE
chore: replace old ruby teams with cloud-sdk-ruby-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-*  @googleapis/ruby-team
+*  @googleapis/cloud-sdk-ruby-team


### PR DESCRIPTION
Bug ID: b/479546763