### PR TITLE
fix: Fixed crashes and incorrect behavior in the set-bang method

### DIFF
--- a/lib/google/cloud/env/lazy_value.rb
+++ b/lib/google/cloud/env/lazy_value.rb
@@ -415,7 +415,7 @@ module Google
             @expires_at = determine_expiry lifetime
             @error = nil
             @retries.finish!
-            if @compute_notify.nil?
+            unless @compute_notify.nil?
               enter_backfill
               leave_compute
             end
@@ -599,7 +599,7 @@ module Google
             enter_backfill
             leave_compute
           end
-          value
+          cached_value
         end
 
         ##
@@ -629,7 +629,7 @@ module Google
             enter_backfill
             leave_compute
           end
-          raise error
+          cached_value
         end
 
         ##

--- a/test/google/cloud/env/lazy_value_test.rb
+++ b/test/google/cloud/env/lazy_value_test.rb
@@ -448,9 +448,9 @@ describe Google::Cloud::Env::LazyValue do
         count += 1
         1
       end
-      cache.set!(2)
-      assert_equal(2, cache.get)
-      assert_equal(0, count)
+      cache.set! 2
+      assert_equal 2, cache.get
+      assert_equal 0, count
     end
 
     it "modifies the value if computation is finished" do
@@ -459,18 +459,18 @@ describe Google::Cloud::Env::LazyValue do
         count += 1
         1
       end
-      assert_equal(1, cache.get)
-      assert_equal(1, count)
-      cache.set!(2)
-      assert_equal(2, cache.get)
-      assert_equal(1, count)
+      assert_equal 1, cache.get
+      assert_equal 1, count
+      cache.set! 2
+      assert_equal 2, cache.get
+      assert_equal 1, count
     end
 
     it "throws away the computation if one is in progress when set! is called" do
       count = 0
       cache = Google::Cloud::Env::LazyValue.new do
         count += 1
-        sleep(0.4)
+        sleep 0.4
         count += 1
         3
       end
@@ -478,12 +478,12 @@ describe Google::Cloud::Env::LazyValue do
         cache.get
       end
       thread2 = Thread.new do
-        sleep(0.1)
+        sleep 0.1
         cache.get
       end
       thread3 = Thread.new do
-        sleep(0.2)
-        cache.set!(4)
+        sleep 0.2
+        cache.set! 4
       end
       thread3.join
       assert_equal 4, cache.get

--- a/test/google/cloud/env/lazy_value_test.rb
+++ b/test/google/cloud/env/lazy_value_test.rb
@@ -441,6 +441,64 @@ describe Google::Cloud::Env::LazyValue do
     end
   end
 
+  describe "#set!" do
+    it "simply sets the value if no computation has occurred" do
+      count = 0
+      cache = Google::Cloud::Env::LazyValue.new do
+        count += 1
+        1
+      end
+      cache.set!(2)
+      assert_equal(2, cache.get)
+      assert_equal(0, count)
+    end
+
+    it "modifies the value if computation is finished" do
+      count = 0
+      cache = Google::Cloud::Env::LazyValue.new do
+        count += 1
+        1
+      end
+      assert_equal(1, cache.get)
+      assert_equal(1, count)
+      cache.set!(2)
+      assert_equal(2, cache.get)
+      assert_equal(1, count)
+    end
+
+    it "throws away the computation if one is in progress when set! is called" do
+      count = 0
+      cache = Google::Cloud::Env::LazyValue.new do
+        count += 1
+        sleep(0.4)
+        count += 1
+        3
+      end
+      thread1 = Thread.new do
+        cache.get
+      end
+      thread2 = Thread.new do
+        sleep(0.1)
+        cache.get
+      end
+      thread3 = Thread.new do
+        sleep(0.2)
+        cache.set!(4)
+      end
+      thread3.join
+      assert_equal 4, cache.get
+      assert_equal 1, count
+      value2 = thread2.join.value
+      assert_equal 4, value2
+      assert_equal 1, count
+      value1 = thread1.join.value
+      assert_equal 4, value1
+      assert_equal 2, count
+      assert_equal 4, cache.get
+      assert_equal 2, count
+    end
+  end
+
   describe "#expire!" do
     it "does nothing if not finished" do
       cache = Google::Cloud::Env::LazyValue.new do


### PR DESCRIPTION
Hey guys,

I was doing some work extracting the LazyValue class for other purposes, and caught a few bugs in the `set!` method. I don't think that method is actually used in the rest of this gem, so it's probably not currently causing problems, but here are the fixes (and a few tests) so that this doesn't cause you issues in the future.