### PR TITLE
feat: Ruby 3.2 minimum and Ruby 4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ruby: "3.1"
-            task: test
-          - os: ubuntu-latest
             ruby: "3.2"
             task: test
           - os: ubuntu-latest
@@ -25,31 +22,37 @@ jobs:
           - os: ubuntu-latest
             ruby: "3.4"
             task: test
+          - os: ubuntu-latest
+            ruby: "4.0"
+            task: test
           - os: macos-latest
-            ruby: "3.4"
+            ruby: "4.0"
             task: test
           - os: windows-latest
-            ruby: "3.4"
+            ruby: "4.0"
             task: test
           - os: ubuntu-latest
-            ruby: "3.4"
+            ruby: "4.0"
             task: rubocop , build , yardoc , linkinator
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Install Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         ruby-version: "${{ matrix.ruby }}"
-    - name: Install NodeJS 18.x
-      uses: actions/setup-node@v4
+    - name: Install NodeJS 24.x
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
-        node-version: "18.x"
+        node-version: "24.x"
     - name: Install tools
       shell: bash
-      run: "gem install --no-document toys && bundle install"
+      run: "gem install --no-document toys"
     - name: Test ${{ matrix.task }}
       shell: bash
-      run: toys do ${{ matrix.task }} < /dev/null
+      run: |
+        for task in $(echo "${{ matrix.task }}" | tr ',' ' '); do
+          toys "$task" < /dev/null
+        done

--- a/.toys/linkinator.rb
+++ b/.toys/linkinator.rb
@@ -32,8 +32,8 @@ end
 def check_links
   cmd = [
     "npx", "linkinator", "./doc",
-    "--reetry-errors",
-    "--skip", "^https?://stackoverflow\\.com/questions/tagged/google-cloud-platform\\+ruby$"
+    "--retry-errors",
+    "--skip", "^https?://(www\\.)?stackoverflow\\.com"
   ]
   result = exec cmd, out: :capture
   puts result.captured_out

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source "https://rubygems.org"
 gemspec
 
 gem "autotest-suffix", "~> 1.1"
-gem "google-style", "~> 1.31.0"
+gem "fiddle", "~> 1.1"
+gem "google-style", "~> 1.32.0"
 gem "minitest", "~> 5.16"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.1"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Metadata Server.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 3.0+.
+This library is supported on Ruby 3.2+.
 
 In general, Google provides official support for CRuby versions that are
 actively supported by the Ruby Core team -- that is, Ruby versions that are

--- a/google-cloud-env.gemspec
+++ b/google-cloud-env.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.files         = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + ["LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 3.1"
+  gem.required_ruby_version = ">= 3.2"
 
   gem.add_dependency "base64", "~> 0.2"
   gem.add_dependency "faraday", ">= 1.0", "< 3.a"


### PR DESCRIPTION
CI edits copied from https://github.com/googleapis/google-auth-library-ruby/blob/main/.github/workflows/ci.yml#L63-L65

Adding stackoverflow as a skip to linkinator links. It looks like the CI action gets 403 errors from their domain sometimes.

Adding `fiddle` as it has been unbundled from Ruby 4.0